### PR TITLE
EZR-7179 Declare strict types no longer required, fixed readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ Rules imported from Doctrine Coding Standard:
 * Abstract classes should not be prefixed with `Abstract`
 * Interfaces should not be suffixed with `Interface`
 * Concrete exception class names should not be suffixed with `Exception`
-* Align equals (`=`) signs in assignments
 * Add spaces around a concatenation operator `$foo = 'Hello ' . 'World!'`;
 * Add spaces between assignment, control and return statements
 * Add spaces after a type cast `$foo = (int) '12345';`
@@ -79,7 +78,6 @@ Changed rules:
 * Don't add any spaces after a negation operator `if (!$cond)`
 * Don't add any spaces before a colon in return type declaration `function (): void {}`
 * Keep `declare()` statement in the same line with `<?php` open tag
-* Always add `declare(strict_types = 1)` at the beginning of a file
 * Keep absolute line length below 120 characters
 
 For full reference of enforcements, go through `src/Easir/ruleset.xml`.

--- a/src/Easir/ruleset.xml
+++ b/src/Easir/ruleset.xml
@@ -30,7 +30,7 @@
         <exclude name="SlevomatCodingStandard.Commenting.DocCommentSpacing.IncorrectAnnotationsGroup"/>
         <!-- Disallow unused use (ignored cause of issue when type from use is used only in static context -->
         <exclude name="SlevomatCodingStandard.Namespaces.UnusedUses.UnusedUse"/>
-        <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes" />
+        <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes"/>
     </rule>
 
     <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing">

--- a/src/Easir/ruleset.xml
+++ b/src/Easir/ruleset.xml
@@ -30,20 +30,12 @@
         <exclude name="SlevomatCodingStandard.Commenting.DocCommentSpacing.IncorrectAnnotationsGroup"/>
         <!-- Disallow unused use (ignored cause of issue when type from use is used only in static context -->
         <exclude name="SlevomatCodingStandard.Namespaces.UnusedUses.UnusedUse"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes" />
     </rule>
 
     <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing">
         <properties>
             <property name="spacesCountBeforeColon" value="0"/>
-        </properties>
-    </rule>
-
-    <!-- Require presence of declare(strict_types = 1) in the same line as php open tag -->
-    <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
-        <properties>
-            <property name="newlinesCountBetweenOpenTagAndDeclare" value="0"/>
-            <property name="newlinesCountAfterDeclare" value="2"/>
-            <property name="spacesCountAroundEqualsSign" value="1"/>
         </properties>
     </rule>
 


### PR DESCRIPTION
Tested on :

```
<?php

$xxx = 'ddddd';
$yyyy = 'dfdfs';
$zzzzzzzzz = 12;

```
It is passing.