### PR TITLE
HES-10 Replaced ^7.1 with >=7.1 for PHP version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     }
   },
   "require": {
-    "php": "^7.1",
+    "php": ">=7.1",
     "doctrine/coding-standard": "^8.2",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
     "slevomat/coding-standard": "^6.4",
@@ -37,7 +37,7 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "1.0.x-dev"
+      "dev-master": "1.1.x-dev"
     }
   },
   "version": "1.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ccdfd601150249e2466d7891b1694d24",
+    "content-hash": "a33d01252dc9b6e486f9a4048bb69072",
     "packages": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -309,7 +309,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.1"
+        "php": ">=7.1"
     },
     "platform-dev": [],
     "plugin-api-version": "2.0.0"


### PR DESCRIPTION
This change is required in order to work with ruleset on PHP 8.0.